### PR TITLE
Use extra rid removal surgery for new symptoms.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use extra rid removal surgery for new symptoms. [deiferni]
 
 
 1.0.0 (2019-07-08)

--- a/ftw/catalogdoctor/command.py
+++ b/ftw/catalogdoctor/command.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from ftw.catalogdoctor.compat import processQueue
 from ftw.catalogdoctor.healthcheck import CatalogHealthCheck
-from ftw.catalogdoctor.surgery import CatalogDoctor
+from ftw.catalogdoctor.scheduler import SurgeryScheduler
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Testing.makerequest import makerequest
@@ -71,15 +71,12 @@ def surgery_command(portal_catalog, args, formatter):
 
     there_is_nothing_we_can_do = []
     formatter.info('Performing surgery:')
-    for unhealthy_rid in result.get_unhealthy_rids():
-        doctor = CatalogDoctor(result.catalog, unhealthy_rid)
-        if doctor.can_perform_surgery():
-            surgery = doctor.perform_surgery()
-            surgery.write_result(formatter)
-            formatter.info('')
-        else:
-            there_is_nothing_we_can_do.append(unhealthy_rid)
+    scheduler = SurgeryScheduler(result, catalog=portal_catalog)
+    there_is_nothing_we_can_do, surgeries = scheduler.perform_surgeries()
 
+    for surgery in surgeries:
+        surgery.write_result(formatter)
+        formatter.info('')
     if there_is_nothing_we_can_do:
         formatter.info('The following unhealthy rids could not be fixed:')
         for unhealthy_rid in there_is_nothing_we_can_do:

--- a/ftw/catalogdoctor/scheduler.py
+++ b/ftw/catalogdoctor/scheduler.py
@@ -1,0 +1,24 @@
+from ftw.catalogdoctor.surgery import CatalogDoctor
+from plone import api
+
+
+class SurgeryScheduler(object):
+    """Performs surgeries based on a healthcheck result."""
+
+    def __init__(self, healtcheck, catalog=None):
+        self.healtcheck = healtcheck
+        self.portal_catalog = catalog or api.portal.get_tool('portal_catalog')
+        self.catalog = self.portal_catalog._catalog
+
+    def perform_surgeries(self):
+        there_is_nothing_we_can_do = []
+        surgeries = []
+        for unhealthy_rid in self.healtcheck.get_unhealthy_rids():
+            doctor = CatalogDoctor(self.catalog, unhealthy_rid)
+            if doctor.can_perform_surgery():
+                surgery = doctor.perform_surgery()
+                surgeries.append(surgery)
+            else:
+                there_is_nothing_we_can_do.append(unhealthy_rid)
+
+        return there_is_nothing_we_can_do, surgeries

--- a/ftw/catalogdoctor/surgery.py
+++ b/ftw/catalogdoctor/surgery.py
@@ -395,12 +395,20 @@ class CatalogDoctor(object):
     When you add symptom tuples to surgeries make sure they are sorted
     alphabetically.
     """
+
     surgeries = {
         (
             'in_metadata_keys_not_in_uids_values',
             'in_paths_keys_not_in_uids_values',
             'in_uuid_unindex_not_in_catalog',
             'in_uuid_unindex_not_in_uuid_index',
+            'uids_tuple_mismatches_paths_tuple',
+        ): RemoveExtraRid,
+        (
+            'in_metadata_keys_not_in_uids_values',
+            'in_paths_keys_not_in_uids_values',
+            'in_uuid_index_not_in_catalog',
+            'in_uuid_unindex_not_in_catalog',
             'uids_tuple_mismatches_paths_tuple',
         ): RemoveExtraRid,
         (

--- a/ftw/catalogdoctor/testing.py
+++ b/ftw/catalogdoctor/testing.py
@@ -2,12 +2,33 @@ from ftw.builder.content import register_dx_content_builders
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
+from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PloneSandboxLayer
 from plone.testing import z2
 from zope.configuration import xmlconfig
-from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
+import logging
+import sys
+
+
+# Capture messages logged by certain indexes, we want to see these messages
+# during test execution for better debugging/analysis.
+# The loggers used by different indexes are not standardized, unfortunately.
+LOG_TO_STDOUT_DURING_TESTRUN = {
+    'BooleanIndex.UnIndex': logging.ERROR,
+    'DateIndex': logging.ERROR,
+    'Products.ZCatalog': logging.ERROR,
+    'Zope.PathIndex': logging.DEBUG,
+    'Zope.UnIndex': logging.ERROR,
+}
+
+loghandler = logging.StreamHandler(stream=sys.stdout)
+loghandler.setLevel(logging.WARNING)
+for name, level in LOG_TO_STDOUT_DURING_TESTRUN.items():
+    logger = logging.getLogger(name)
+    logger.addHandler(loghandler)
+    logger.setLevel(level)
 
 
 class CatalogdoctorLayer(PloneSandboxLayer):

--- a/ftw/catalogdoctor/tests/__init__.py
+++ b/ftw/catalogdoctor/tests/__init__.py
@@ -11,7 +11,7 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from random import randint
 from StringIO import StringIO
-from unittest2 import TestCase
+from unittest import TestCase
 import transaction
 import uuid
 

--- a/ftw/catalogdoctor/tests/__init__.py
+++ b/ftw/catalogdoctor/tests/__init__.py
@@ -4,6 +4,7 @@ from Acquisition import aq_parent
 from ftw.catalogdoctor.command import doctor_cmd
 from ftw.catalogdoctor.compat import processQueue
 from ftw.catalogdoctor.healthcheck import CatalogHealthCheck
+from ftw.catalogdoctor.scheduler import SurgeryScheduler
 from ftw.catalogdoctor.testing import CATALOGDOCTOR_FUNCTIONAL
 from plone import api
 from plone.app.testing import setRoles
@@ -61,6 +62,11 @@ class FunctionalTestCase(TestCase):
         self.maybe_process_indexing_queue()  # enforce up to date catalog
         healthcheck = CatalogHealthCheck(self.portal_catalog)
         return healthcheck.run()
+
+    def perform_surgeries(self, healthcheck_result):
+        scheduler = SurgeryScheduler(
+            healthcheck_result, catalog=self.portal_catalog)
+        return scheduler.perform_surgeries()
 
     def choose_next_rid(self):
         """Return a currently unused rid for testing.
@@ -184,14 +190,15 @@ class FunctionalTestCase(TestCase):
         self.maybe_process_indexing_queue()
         return ob
 
-    def recatalog_object_with_new_rid(self, obj):
+    def recatalog_object_with_new_rid(self, obj, drop_from_indexes=True):
         """Make catalog unhealthy by recataloging an object with a new rid.
 
         This will leave the old rid behind in catalog metadata and in the
         rid->path mapping but remove it from all indexes.
 
         """
-        self.drop_object_from_catalog_indexes(obj)
+        if drop_from_indexes:
+            self.drop_object_from_catalog_indexes(obj)
 
         path = '/'.join(obj.getPhysicalPath())
         del self.catalog.uids[path]

--- a/ftw/catalogdoctor/tests/test_surgery.py
+++ b/ftw/catalogdoctor/tests/test_surgery.py
@@ -44,7 +44,7 @@ class TestSurgery(FunctionalTestCase):
 
         doctor = CatalogDoctor(self.catalog, unhealthy_rid)
         self.assertIs(RemoveExtraRid, doctor.get_surgery())
-        doctor.perform_surgery()
+        self.perform_surgeries(result)
 
         result = self.run_healthcheck()
         self.assertTrue(result.is_healthy())
@@ -67,7 +67,7 @@ class TestSurgery(FunctionalTestCase):
 
         doctor = CatalogDoctor(self.catalog, unhealthy_rid)
         self.assertIs(RemoveExtraRid, doctor.get_surgery())
-        doctor.perform_surgery()
+        self.perform_surgeries(result)
 
         result = self.run_healthcheck()
         self.assertTrue(result.is_healthy())
@@ -93,7 +93,7 @@ class TestSurgery(FunctionalTestCase):
 
         doctor = CatalogDoctor(self.catalog, unhealthy_rid)
         self.assertIs(RemoveOrphanedRid, doctor.get_surgery())
-        doctor.perform_surgery()
+        self.perform_surgeries(result)
 
         result = self.run_healthcheck()
         self.assertTrue(result.is_healthy())
@@ -118,7 +118,7 @@ class TestSurgery(FunctionalTestCase):
 
         doctor = CatalogDoctor(self.catalog, unhealthy_rid)
         self.assertIs(RemoveOrphanedRid, doctor.get_surgery())
-        doctor.perform_surgery()
+        self.perform_surgeries(result)
 
         result = self.run_healthcheck()
         self.assertTrue(result.is_healthy())
@@ -140,7 +140,7 @@ class TestSurgery(FunctionalTestCase):
 
         doctor = CatalogDoctor(self.catalog, unhealthy_rid)
         self.assertIs(ReindexMissingUUID, doctor.get_surgery())
-        doctor.perform_surgery()
+        self.perform_surgeries(result)
 
         result = self.run_healthcheck()
         self.assertTrue(result.is_healthy())
@@ -170,7 +170,7 @@ class TestSurgery(FunctionalTestCase):
         doctor = CatalogDoctor(self.catalog, unhealthy_rid)
         self.assertIs(RemoveRidOrReindexObject, doctor.get_surgery())
         with self.assertRaises(CantPerformSurgery):
-            doctor.perform_surgery()
+            self.perform_surgeries(result)
 
     def test_surgery_remove_object_moved_into_parent_and_found_via_acquisition(self):
         grandchild = create(Builder('folder')
@@ -204,7 +204,7 @@ class TestSurgery(FunctionalTestCase):
 
         doctor = CatalogDoctor(self.catalog, unhealthy_rid)
         self.assertIs(RemoveRidOrReindexObject, doctor.get_surgery())
-        doctor.perform_surgery()
+        self.perform_surgeries(result)
 
         result = self.run_healthcheck()
         self.assertTrue(result.is_healthy())
@@ -227,7 +227,7 @@ class TestSurgery(FunctionalTestCase):
 
         doctor = CatalogDoctor(self.catalog, unhealthy_rid)
         self.assertIs(RemoveRidOrReindexObject, doctor.get_surgery())
-        doctor.perform_surgery()
+        self.perform_surgeries(result)
 
         result = self.run_healthcheck()
         self.assertTrue(result.is_healthy())
@@ -283,7 +283,7 @@ class TestSurgery(FunctionalTestCase):
 
         doctor = CatalogDoctor(self.catalog, unhealthy_rid)
         self.assertIs(RemoveRidOrReindexObject, doctor.get_surgery())
-        doctor.perform_surgery()
+        self.perform_surgeries(result)
 
         self.assertEqual(1, len(self.catalog))
         self.assertNotIn(rid, self.catalog.paths)


### PR DESCRIPTION
When encountering extra RIDs the UUID index for the correct RID can be in different states. We have already encountered and documented cases where it is missing or inserted partially:

https://github.com/4teamwork/ftw.catalogdoctor/blob/1ac6df352015336769ffd8977908fa36cf0e4ce5/ftw/catalogdoctor/tests/test_surgery.py#L27-L73

In this PR we add the third case where the UID is stale and needs updating. We also introduce a scheduler that lets doctors perform surgeries and use it in tests. This is a leftover because of my initial assumption that ordering of surgeries may be an issue. It turned out differently but i will leave the scheduler in place hoping it may prove useful eventually.

We also
- Drop `unittest2` as a depdendency.
- Capture things logged by indexers during testing. This helps a lot when debugging issues with tests.

Jira: https://4teamwork.atlassian.net/browse/CA-365