### PR TITLE
Check for shorter path rather than direct parent in surgery safeguard.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
+- Check for shorter path rather than direct parent in surgery safeguard. [deiferni]
 - Use extra rid removal surgery for new symptoms. [deiferni]
 
 

--- a/ftw/catalogdoctor/tests/test_utils.py
+++ b/ftw/catalogdoctor/tests/test_utils.py
@@ -4,7 +4,9 @@ from ftw.catalogdoctor.tests import FunctionalTestCase
 from ftw.catalogdoctor.tests import Mock
 from ftw.catalogdoctor.utils import contains_or_equals_rid
 from ftw.catalogdoctor.utils import find_keys_pointing_to_rid
+from ftw.catalogdoctor.utils import is_shorter_path_to_same_file
 from Products.PluginIndexes.common.UnIndex import UnIndex
+from unittest import TestCase
 
 
 class TestFindKeysPointingToRid(FunctionalTestCase):
@@ -67,3 +69,68 @@ class TestContainsOrEqualsRid(FunctionalTestCase):
 
     def test_equals_rid_false(self):
         self.assertFalse(contains_or_equals_rid(123, 77))
+
+
+class TestIsShorterPath(TestCase):
+
+    def test_truthy_is_shorter_path_trailing_leading_slashes_ignored(self):
+        self.assertTrue(
+            is_shorter_path_to_same_file('bar', 'foo/bar'))
+        self.assertTrue(
+            is_shorter_path_to_same_file('bar', '/foo/bar'))
+        self.assertTrue(
+            is_shorter_path_to_same_file('bar', '/foo/bar/'))
+        self.assertTrue(
+            is_shorter_path_to_same_file('/bar', 'foo/bar'))
+        self.assertTrue(
+            is_shorter_path_to_same_file('/bar', '/foo/bar'))
+        self.assertTrue(
+            is_shorter_path_to_same_file('/bar', '/foo/bar/'))
+        self.assertTrue(
+            is_shorter_path_to_same_file('/bar/', 'foo/bar'))
+        self.assertTrue(
+            is_shorter_path_to_same_file('/bar/', '/foo/bar'))
+        self.assertTrue(
+            is_shorter_path_to_same_file('/bar/', '/foo/bar/'))
+
+    def test_truthy_is_shorter_path_several_segments_shorter(self):
+        self.assertTrue(
+            is_shorter_path_to_same_file('/bar/', '/foo/bar/'))
+        self.assertTrue(
+            is_shorter_path_to_same_file('/bar/', 'foo/qux/bar'))
+        self.assertTrue(
+            is_shorter_path_to_same_file('bar/', '/foo/1/2/4/bar'))
+
+    def test_falsy_is_shorter_path_same_path(self):
+        self.assertFalse(
+            is_shorter_path_to_same_file('foo/bar', 'foo/bar'))
+        self.assertFalse(
+            is_shorter_path_to_same_file('/foo/bar', 'foo/bar'))
+        self.assertFalse(
+            is_shorter_path_to_same_file('foo/bar/', 'foo/bar'))
+        self.assertFalse(
+            is_shorter_path_to_same_file('/foo/bar/', 'foo/bar'))
+        self.assertFalse(
+            is_shorter_path_to_same_file('foo/bar', 'foo/bar'))
+        self.assertFalse(
+            is_shorter_path_to_same_file('/foo/bar', '/foo/bar'))
+        self.assertFalse(
+            is_shorter_path_to_same_file('/foo/bar', 'foo/bar/'))
+        self.assertFalse(
+            is_shorter_path_to_same_file('/foo/bar/', '/foo/bar/'))
+
+    def test_falsy_is_shorter_path_longer_path(self):
+        self.assertFalse(
+            is_shorter_path_to_same_file('/foo/qux/bar', '/foo/bar'))
+        self.assertFalse(
+            is_shorter_path_to_same_file('/foo/1/2/3/4/bar', '/foo/bar'))
+
+    def test_falsy_is_shorter_path_different_path(self):
+        self.assertFalse(
+            is_shorter_path_to_same_file('/foo', '/foo/bar'))
+        self.assertFalse(
+            is_shorter_path_to_same_file('/foo/quxbar', '/foo/bar'))
+
+    def test_falsy_is_shorter_path_different_order(self):
+        self.assertFalse(
+            is_shorter_path_to_same_file('/foo/1/zwo/bar', '/foo/zwo/1/bar'))

--- a/ftw/catalogdoctor/utils.py
+++ b/ftw/catalogdoctor/utils.py
@@ -18,3 +18,26 @@ def contains_or_equals_rid(rid, rids_or_rid):
         return rid in rids_or_rid
     except TypeError:
         return rid == rids_or_rid
+
+
+def is_shorter_path_to_same_file(shorter, longer):
+    """Return whether `shorter` is a part of `longer`.
+
+    Will return `True` when `shorter` is a path pointing to the same last
+    segment but shortened by some intermediate segments that are present in
+    `longer`.
+    """
+    shorter_path_segments = shorter.rstrip('/').strip('/').split('/')
+    longer_segments = longer.rstrip('/').strip('/').split('/')
+    if len(shorter_path_segments) >= len(longer_segments):
+        return False
+
+    # last element must be the same.
+    if shorter_path_segments.pop() != longer_segments.pop():
+        return False
+
+    # every segment in longer must be present in shorter in correct order.
+    for segment in longer_segments:
+        if shorter_path_segments and shorter_path_segments[0] == segment:
+            shorter_path_segments.pop(0)
+    return len(shorter_path_segments) == 0


### PR DESCRIPTION
With this PR we prevent the doctor from aborting surgery by making a paranoia check somewhat less strict. Currently the special handling for objects moved up in the hierarchy (and thus still traversable via their old path due to acquisition) would abort when parent for object acquired with new path and old path was the same:
https://github.com/4teamwork/ftw.catalogdoctor/blob/164a9bb90b068862f01caffd3c6604145515b8cf/ftw/catalogdoctor/surgery.py#L363-L372

This does not cover cases where the object has not been moved directly, but instead one of its parents has been moved (moving the contained object, too). The check prevented running `doctor` in some productive deployments as described in https://4teamwork.atlassian.net/browse/CA-365?focusedCommentId=17466.

With this PR we change the safeguard to check for objects moved into their parent hierarchy in some manner. This drills down to the new path being some path segments (not the file though) shorter.

Jira: https://4teamwork.atlassian.net/browse/CA-365

