### PR TITLE
Implement reindexing objects for orphaned rids.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
+- Implement reindexing objects when still traversable for orphaned rids. [deiferni]
 - Check for shorter path rather than direct parent in surgery safeguard. [deiferni]
 - Use extra rid removal surgery for new symptoms. [deiferni]
 


### PR DESCRIPTION
Currently when we encounter an orphaned rid we assume the object has been removed from the tree and guard against it in: https://github.com/4teamwork/ftw.catalogdoctor/blob/d8bca50306ab8896f5967a40c37647fe3a3c6ea3/ftw/catalogdoctor/surgery.py#L268-L271

There are cases where the rid is orphaned in the catalog but the object is still around. See https://4teamwork.atlassian.net/browse/CA-365?focusedCommentId=17465 for description in production. 

In this PR we change the implementation for such cases to no longer abort but to first cleanup traces of the old object, then reindex it to create a new rid in the catalog.

We could solve this differently and attempt to repair the existing record instead of creating a new one. But since the `path->rid` mapping is the primary source of truth for the catalog i'd rather create a new rid for such cases.

Jira: https://4teamwork.atlassian.net/browse/CA-365