### PR TITLE
Drop object if it is a duplicate from acquisition when fixing uids.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,14 @@ There is also a `--dry-run` parameter that prevents committing changes.
     $ bin/instance doctor --dry-run surgery
 
 
+Debugging
+=========
+
+If you need to debug/analyze issues that ``ftw.catalogdoctor`` cannot fix yet
+have a look at the ``debug`` module. It provides useful functions to ``pprint``
+or inspect catalog state.
+
+
 Installation
 ============
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
+- Drop duplicate objects from Acquisition when fixing UID index. [deiferni]
 - Implement reindexing objects when still traversable for orphaned rids. [deiferni]
 - Check for shorter path rather than direct parent in surgery safeguard. [deiferni]
 - Use extra rid removal surgery for new symptoms. [deiferni]

--- a/ftw/catalogdoctor/debug.py
+++ b/ftw/catalogdoctor/debug.py
@@ -1,4 +1,17 @@
+from ftw.catalogdoctor.utils import find_keys_pointing_to_rid
+from plone import api
+from plone.app.folder.nogopip import GopipIndex
 from pprint import pprint
+from Products.ExtendedPathIndex.ExtendedPathIndex import ExtendedPathIndex
+from Products.PluginIndexes.BooleanIndex.BooleanIndex import BooleanIndex
+from Products.PluginIndexes.common.UnIndex import UnIndex
+from Products.PluginIndexes.DateRangeIndex.DateRangeIndex import DateRangeIndex
+from Products.PluginIndexes.PathIndex.PathIndex import PathIndex
+from Products.ZCTextIndex.ZCTextIndex import ZCTextIndex
+
+
+_marker = object()
+_no_entry = '<NO ENTRY>'
 
 
 def btrees_to_python_collections(maybe_btrees):
@@ -56,3 +69,162 @@ def pprint_btrees(btrees):
 
     """
     pprint(btrees_to_python_collections(btrees))
+
+
+def pprint_obj_catalog_data(obj, metadata=False):
+    """Pretty-print data in catalog for a content object obj."""
+
+    portal_catalog = api.portal.get_tool('portal_catalog')
+    obj_path = '/'.join(obj.getPhysicalPath())
+    zcatalog = portal_catalog._catalog
+
+    rid = zcatalog.uids.get(obj_path, _no_entry)
+    pprint(get_catalog_data(rid, obj_path, metadata=metadata))
+
+
+def pprint_rid_catalog_data(rid, metadata=False):
+    """Pretty-print data in catalog for rid."""
+
+    portal_catalog = api.portal.get_tool('portal_catalog')
+    zcatalog = portal_catalog._catalog
+
+    if rid not in zcatalog.uids:
+        rid = _no_entry
+    uid = zcatalog.paths.get(rid, _no_entry)
+    pprint(get_catalog_data(rid, uid, metadata=metadata))
+
+
+def get_catalog_data(rid, uid, metadata=False):
+    """Return all data in catalog for rid and uid."""
+
+    if rid and uid:
+        raise TypeError('Either specify rid or uid, both are unsupported.')
+
+    portal_catalog = api.portal.get_tool('portal_catalog')
+    zcatalog = portal_catalog._catalog
+
+    data = {}
+    if rid:
+        uid = zcatalog.paths.get(rid, _no_entry)
+    elif uid:
+        rid = zcatalog.uids.get(uid, _no_entry)
+        # early abort when we lookup the rid but can't find it
+        if rid == _no_entry:
+            data['uids (path->rid)'] = {uid: rid}
+            return data
+
+    data['indexes'] = get_extended_indexes_data(zcatalog, idxs, rid)
+    if metadata:
+        data['metadata'] = portal_catalog.getMetadataForRID(rid)
+
+    data['paths (rid->path)'] = {rid: uid}
+    # handle when we are passed a rid which is in indexes but not in uids
+    if rid not in zcatalog.paths:
+        rid = _no_entry
+    data['uids (path->rid)'] = {uid: rid}
+
+    return data
+
+
+def get_extended_indexes_data(zcatalog, rid):
+    """Return all data stored in all zcatalog indexes for rid."""
+
+    indexes_data = {}
+    for index_name in zcatalog.indexes:
+        index = zcatalog.getIndex(index_name)
+        indexes_data[index_name] = get_extended_index_data(index, rid)
+    return indexes_data
+
+
+def get_extended_index_data(index, rid):
+    """Return all data stored in an index for rid.
+
+    This usually includes backward and forward indexes and also helper indexes
+    if available.
+    """
+    if isinstance(index, GopipIndex):
+        return '<UNSUPPORTED>'
+
+    index_data = {}
+
+    if isinstance(index, PathIndex):
+        index_data['unindex'] = {}
+        unindex_value = index._unindex.get(rid, _marker)
+        if unindex_value is not _marker:
+            index_data['unindex'][rid] = unindex_value
+
+        index_data['index'] = {}
+        for component, level_to_rid in index._index.items():
+            for level, rids in level_to_rid.items():
+                if rid in rids:
+                    index_data['index'][(component, level,)] = rid
+
+        if isinstance(index, ExtendedPathIndex):
+            index_data['index_items'] = {}
+            index_values = find_keys_pointing_to_rid(index._index_items, rid)
+            for index_value in index_values:
+                index_data['index_items'][index_value] = rid
+
+            index_data['index_parents'] = {}
+            index_values = find_keys_pointing_to_rid(index._index_parents, rid)
+            for index_value in index_values:
+                index_data['index_parents'][index_value] = rid
+
+    elif isinstance(index, ZCTextIndex):
+        # just show what word ids are available for the rid to indicate it
+        # is present in the index. not bothering to look up the acual
+        # string represented by the term. may be omitted if not useful.
+        index_data['docwords'] = {}
+        if index.index.has_doc(rid):
+            index_data['docwords'][rid] = index.index.get_words(rid)
+
+    elif isinstance(index, DateRangeIndex):
+        index_data['always'] = []
+        if rid in index._always:
+            index_data['always'] = [rid]
+
+        index_data['since_only'] = {}
+        index_values = find_keys_pointing_to_rid(index._since_only, rid)
+        for index_value in index_values:
+            index_data['since_only'][index_value] = rid
+
+        index_data['until_only'] = {}
+        index_values = find_keys_pointing_to_rid(index._until_only, rid)
+        for index_value in index_values:
+            index_data['until_only'][index_value] = rid
+
+        index_data['since'] = {}
+        index_values = find_keys_pointing_to_rid(index._since, rid)
+        for index_value in index_values:
+            index_data['since'][index_value] = rid
+
+        index_data['until'] = {}
+        index_values = find_keys_pointing_to_rid(index._until, rid)
+        for index_value in index_values:
+            index_data['until'][index_value] = rid
+
+        index_data['unindex'] = {}
+        unindex_value = index._unindex.get(rid, _marker)
+        if unindex_value is not _marker:
+            index_data['unindex'][rid] = unindex_value
+
+    elif isinstance(index, BooleanIndex):
+        # _index is special an only contains either `True` or `False`
+        # values, we are just interested in _unindex
+        index_data['unindex'] = {}
+        unindex_value = index._unindex.get(rid, _marker)
+        if unindex_value is not _marker:
+            index_data['unindex'][rid] = unindex_value
+
+    elif isinstance(index, UnIndex):
+        index_data['unindex'] = {}
+        unindex_value = index._unindex.get(rid, _marker)
+        if unindex_value is not _marker:
+            index_data['unindex'][rid] = unindex_value
+
+        index_data['index'] = {}
+        index_values = find_keys_pointing_to_rid(index._index, rid)
+        for index_value in index_values:
+            index_data['index'][index_value] = rid
+
+    return index_data

--- a/ftw/catalogdoctor/surgery.py
+++ b/ftw/catalogdoctor/surgery.py
@@ -203,6 +203,35 @@ class Surgery(object):
         self.surgery_log.append(
             "Removed path from uids (the path->rid mapping).")
 
+    def is_potential_rid_duplicate_from_acquisition(self, obj, path):
+        obj_path = '/'.join(obj.getPhysicalPath())
+        return obj_path != path
+
+    def unindex_rid_duplicate_from_acquisition(self, obj, path, rid):
+        """special case when the object or one of its parents has been moved.
+
+        the object can be traversed as it is found via acquisition.
+
+        we only want to apply this fix for objects moved into their
+        parent hierarchy in some manner. abort if this is not the case.
+        maybe this restriction can be loosened a bit  eventually but for
+        now it covers what we've seen in production.
+        """
+        obj_path = '/'.join(obj.getPhysicalPath())
+        if not is_shorter_path_to_same_file(obj_path, path):
+            raise CantPerformSurgery(
+                "Object path after traversing {} differs from path before "
+                "traversing, but correct path {} cannot be found in "
+                "catalog.".format(obj_path, path))
+
+        self.unindex_rid_from_all_catalog_indexes(rid)
+        self.delete_rid_from_paths(rid)
+        self.delete_rid_from_metadata(rid)
+        self.delete_path_from_uids(path)
+        self.change_catalog_length(-1)
+        self.surgery_log.append("Removed duplicate acquired via "
+                                "acquisition from catalog.")
+
     def change_catalog_length(self, delta):
         self.catalog._length.change(delta)
 
@@ -309,27 +338,8 @@ class ReindexMissingUUID(Surgery):
             raise CantPerformSurgery(
                 "Missing object at {}".format(path))
 
-        # special case when the object or one of its parents has been moved.
-        # the object can be traversed as it is found via acquisition.
-        obj_path = '/'.join(obj.getPhysicalPath())
-        if obj_path != path:
-            # we only want to apply this fix for objects moved into their
-            # parent hierarchy in some manner. abort if this is not the case.
-            # maybe this restriction can be loosened a bit  eventually but for
-            # now it covers what we've seen in production.
-            if not is_shorter_path_to_same_file(obj_path, path):
-                raise CantPerformSurgery(
-                    "Object path after traversing {} differs from path before "
-                    "traversing, but correct path {} cannot be found in "
-                    "catalog.".format(obj_path, path))
-
-            self.unindex_rid_from_all_catalog_indexes(rid)
-            self.delete_rid_from_paths(rid)
-            self.delete_rid_from_metadata(rid)
-            self.delete_path_from_uids(path)
-            self.change_catalog_length(-1)
-            self.surgery_log.append("Removed duplicate acquired via "
-                                    "acquisition from catalog.")
+        if self.is_potential_rid_duplicate_from_acquisition(obj, path):
+            self.unindex_rid_duplicate_from_acquisition(obj, path, rid)
             return
 
         # update UID index
@@ -391,29 +401,10 @@ class RemoveRidOrReindexObject(Surgery):
             self.delete_rid_from_metadata(rid)
             self.delete_path_from_uids(path)
             self.change_catalog_length(-1)
-
             return
 
-        # special case when the object or one of its parents has been moved.
-        # the object can be traversed as it is found via acquisition.
-        obj_path = '/'.join(obj.getPhysicalPath())
-        if obj_path != path:
-            # we only want to apply this fix for objects moved into their
-            # parent hierarchy in some manner. abort if this is not the case.
-            # maybe this restriction can be loosened a bit  eventually but for
-            # now it covers what we've seen in production.
-            if not is_shorter_path_to_same_file(obj_path, path):
-                raise CantPerformSurgery(
-                    "Object path after traversing {} differs from path before "
-                    "traversing, but correct path {} cannot be found in "
-                    "catalog.".format(obj_path, path))
-
-            self.unindex_rid_from_all_catalog_indexes(rid)
-            self.delete_rid_from_paths(rid)
-            self.delete_rid_from_metadata(rid)
-            self.delete_path_from_uids(path)
-            self.change_catalog_length(-1)
-
+        if self.is_potential_rid_duplicate_from_acquisition(obj, path):
+            self.unindex_rid_duplicate_from_acquisition(obj, path, rid)
             return
 
         # the object is still there and somehow vanished from the indexes.

--- a/ftw/catalogdoctor/tests/test_debug.py
+++ b/ftw/catalogdoctor/tests/test_debug.py
@@ -1,0 +1,120 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.catalogdoctor.debug import get_catalog_data
+from ftw.catalogdoctor.tests import FunctionalTestCase
+from ftw.testing import freeze
+from ftw.testing import staticuid
+import pytz
+
+
+class TestDebug(FunctionalTestCase):
+
+    maxDiff = None
+
+    expected = {
+        'indexes': {
+            'Creator': {'index': {'test_user_1_': 97},
+                        'unindex': {97: 'test_user_1_'}
+                        },
+            'Date': {'index': {1080936000: 97}, 'unindex': {97: 1080936000}},
+            'Description': {'docwords': {97: []}},
+            'Subject': {'index': {}, 'unindex': {}},
+            'Type': {'index': {u'Folder': 97}, 'unindex': {97: u'Folder'}},
+            'UID': {'index': {'setUp000000000000000000000000001': 97},
+                    'unindex': {97: 'setUp000000000000000000000000001'}},
+            'allowedRolesAndUsers': {'index': {'Anonymous': 97},
+                                     'unindex': {97: ['Anonymous']}},
+            'cmf_uid': {'index': {}, 'unindex': {}},
+            'commentators': {'index': {}, 'unindex': {}},
+            'created': {'index': {1080936000: 97},
+                        'unindex': {97: 1080936000}},
+            'effective': {'index': {1055334120: 97},
+                          'unindex': {97: 1055334120}},
+            'effectiveRange': {'always': [],
+                               'since': {},
+                               'since_only': {-1560: 97},
+                               'unindex': {97: (-1560, None)},
+                               'until': {},
+                               'until_only': {}},
+            'end': {'index': {}, 'unindex': {}},
+            'expires': {'index': {1339244520: 97},
+                        'unindex': {97: 1339244520}},
+            'getId': {'index': {'folder': 97}, 'unindex': {97: 'folder'}},
+            'getObjPositionInParent': '<UNSUPPORTED>',
+            'getRawRelatedItems': {'index': {}, 'unindex': {}},
+            'id': {'index': {'folder': 97}, 'unindex': {97: 'folder'}},
+            'in_reply_to': {'index': {}, 'unindex': {}},
+            'is_default_page': {'unindex': {97: 0}},
+            'is_folderish': {'unindex': {97: 1}},
+            'meta_type': {'index': {'Dexterity Container': 97},
+                          'unindex': {97: 'Dexterity Container'}},
+            'modified': {'index': {1080936000: 97},
+                         'unindex': {97: 1080936000}},
+            'path': {'index': {(None, 1): 97,
+                               ('folder', 1): 97,
+                               ('plone', 0): 97},
+                     'index_items': {'/plone/folder': 97},
+                     'index_parents': {'/plone': 97},
+                     'unindex': {97: '/plone/folder'}},
+            'portal_type': {'index': {'Folder': 97},
+                            'unindex': {97: 'Folder'}},
+            'review_state': {'index': {}, 'unindex': {}},
+            'sortable_title': {'index': {'folder': 97},
+                               'unindex': {97: 'folder'}},
+            'start': {'index': {}, 'unindex': {}},
+            'sync_uid': {'index': {}, 'unindex': {}},
+            'total_comments': {'index': {0: 97}, 'unindex': {97: 0}}
+        },
+        'paths (rid->path)': {97: '/plone/folder'},
+        'uids (path->rid)': {'/plone/folder': 97}
+    }
+
+    @staticuid()
+    def setUp(self):
+        super(TestDebug, self).setUp()
+
+        self.grant('Contributor')
+        now = datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)
+        with freeze(now):
+            self.obj = create(Builder('folder').titled(u'Folder'))
+
+    def test_debug_get_catalog_data_rid(self):
+        actual = get_catalog_data(rid=self.get_rid(self.obj))
+        # interfaces differ between plone versions, just make sure some are
+        # there
+        self.assertIn(97, actual['indexes']['object_provides']['unindex'])
+        self.assertIn('plone.app.contenttypes.interfaces.IFolder',
+                      actual['indexes']['object_provides']['index'])
+        del actual['indexes']['object_provides']
+        # word-ids are different, assert manually
+        # 'SearchableText': {'docwords': {97: [256139963, 256139963]}}
+        self.assertIn(97, actual['indexes']['SearchableText']['docwords'])
+        del actual['indexes']['SearchableText']
+        # word-ids are different, assert manually
+        # 'Title': {'docwords': {97: [256139963]}}
+        self.assertIn(97, actual['indexes']['Title']['docwords'])
+        del actual['indexes']['Title']
+        self.assertEqual(self.expected, actual)
+
+    def test_debug_get_catalog_data_uid(self):
+        actual = get_catalog_data(uid=self.get_physical_path(self.obj))
+        # interfaces differ between plone versions, just make sure some are
+        # there
+        self.assertIn(97, actual['indexes']['object_provides']['unindex'])
+        self.assertIn('plone.app.contenttypes.interfaces.IFolder',
+                      actual['indexes']['object_provides']['index'])
+        del actual['indexes']['object_provides']
+        # word-ids are different, assert manually
+        # 'SearchableText': {'docwords': {97: [256139963, 256139963]}}
+        self.assertIn(97, actual['indexes']['SearchableText']['docwords'])
+        del actual['indexes']['SearchableText']
+        # word-ids are different, assert manually
+        # 'Title': {'docwords': {97: [256139963]}}
+        self.assertIn(97, actual['indexes']['Title']['docwords'])
+        del actual['indexes']['Title']
+        self.assertEqual(self.expected, actual)
+
+    def test_debug_get_catalog_data_exclusive_parameters(self):
+        with self.assertRaises(TypeError):
+            get_catalog_data(rid=1234, uid='/something')

--- a/ftw/catalogdoctor/tests/test_debug.py
+++ b/ftw/catalogdoctor/tests/test_debug.py
@@ -115,6 +115,22 @@ class TestDebug(FunctionalTestCase):
         del actual['indexes']['Title']
         self.assertEqual(self.expected, actual)
 
+    def test_debug_get_catalog_data_limited_indexes(self):
+        expected = {
+            'indexes': {
+                'Type': {'index': {u'Folder': 97}, 'unindex': {97: u'Folder'}},
+                'UID': {'index': {'setUp000000000000000000000000001': 97},
+                        'unindex': {97: 'setUp000000000000000000000000001'}},
+                'portal_type': {'index': {'Folder': 97},
+                                'unindex': {97: 'Folder'}},
+            },
+            'paths (rid->path)': {97: '/plone/folder'},
+            'uids (path->rid)': {'/plone/folder': 97}
+        }
+        actual = get_catalog_data(uid=self.get_physical_path(self.obj),
+                                  idxs=['Type', 'UID', 'portal_type'])
+        self.assertEqual(expected, actual)
+
     def test_debug_get_catalog_data_exclusive_parameters(self):
         with self.assertRaises(TypeError):
             get_catalog_data(rid=1234, uid='/something')

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ tests_require = [
     'plone.app.contenttypes',
     'plone.app.testing',
     'plone.testing',
+    'pytz',
     'zope.configuration',
 ]
 


### PR DESCRIPTION
With this PR weadd special handling for objects that are in the catalog twice (once acquisition wrapped, once with their `aq_inner`) when the UID index is inconsistent. We already have special handling for this in the generic reindexing surgery:

https://github.com/4teamwork/ftw.catalogdoctor/blob/724c2890fb8693391d37ff651127b2c701fee664/ftw/catalogdoctor/surgery.py#L374-L394

The specialized `ReindexMissingUUID` surgery could maybe dropped and replaced with the generic implementation. I did not want to do that right now as the symptoms encountered by `healthcheck` differ.

I have also added extensive debugging tools, up to now these were just some scripts i used to type into a debug shell. This adds some amount of duplication between the debug tools and the surgery classes but not enough to extract something generic. It also has the advantage that everything in `debug.py` is implemented in functions and can be pasted into a debug shell in case `ftw.catalogdoctor` is not installed or only an older version is available.

_I have already used and tested said debug tools to find the issue fixed in this PR._

I will cut a new release once this PR is ✅  &nbsp;and :shipit:&nbsp;.

Jira: https://4teamwork.atlassian.net/browse/CA-365
