### PR TITLE
Defer reindex until removal from indexes is done, document fix for one more problem.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Defer reindex until removal from indexes is done, introduce post-op. [deiferni]
 
 
 1.1.0 (2020-09-30)

--- a/ftw/catalogdoctor/command.py
+++ b/ftw/catalogdoctor/command.py
@@ -69,21 +69,11 @@ def surgery_command(portal_catalog, args, formatter):
         formatter.info('Catalog is healthy, no surgery is needed.')
         return
 
-    there_is_nothing_we_can_do = []
     formatter.info('Performing surgery:')
     scheduler = SurgeryScheduler(result, catalog=portal_catalog)
-    there_is_nothing_we_can_do, surgeries = scheduler.perform_surgeries()
-
-    for surgery in surgeries:
-        surgery.write_result(formatter)
-        formatter.info('')
-    if there_is_nothing_we_can_do:
-        formatter.info('The following unhealthy rids could not be fixed:')
-        for unhealthy_rid in there_is_nothing_we_can_do:
-            unhealthy_rid.write_result(formatter)
-            formatter.info('')
-
-        formatter.info('Not all health problems could be fixed, aborting.')
+    scheduler.perform_surgeries()
+    scheduler.write_result(formatter)
+    if not scheduler.is_successful():
         return
 
     processQueue()

--- a/ftw/catalogdoctor/debug.py
+++ b/ftw/catalogdoctor/debug.py
@@ -128,11 +128,24 @@ def get_catalog_data(rid=None, uid=None, idxs=None, metadata=False):
     if metadata:
         data['metadata'] = portal_catalog.getMetadataForRID(rid)
 
-    data['paths (rid->path)'] = {rid: uid}
-    # handle when we are passed a rid which is in indexes but not in uids
-    if rid not in zcatalog.paths:
-        rid = _no_entry
-    data['uids (path->rid)'] = {uid: rid}
+    # get data in uids/paths and make sure to display what is actually stored
+    # in there, not the argument we are passed in by re-fetching the
+    # information from the data structures.
+    uid_in_paths = zcatalog.paths.get(rid, _no_entry)  # placeholder when empty
+    paths_data = {rid: uid_in_paths}
+    # also get potential duplicates
+    for key, value in zcatalog.paths.items():
+        if value == uid and key != rid:
+            paths_data[key] = value
+    data['paths (rid->path)'] = paths_data
+
+    rid_in_uids = zcatalog.uids.get(uid, _no_entry)  # placeholder when empty
+    uids_data = {uid: rid_in_uids}
+    # also get potential duplicates
+    for key, value in zcatalog.uids.items():
+        if value == rid and key != uid:
+            uids_data[key] = value
+    data['uids (path->rid)'] = uids_data
 
     return data
 

--- a/ftw/catalogdoctor/scheduler.py
+++ b/ftw/catalogdoctor/scheduler.py
@@ -9,16 +9,34 @@ class SurgeryScheduler(object):
         self.healtcheck = healtcheck
         self.portal_catalog = catalog or api.portal.get_tool('portal_catalog')
         self.catalog = self.portal_catalog._catalog
+        self.doctors = [
+            CatalogDoctor(self.catalog, unhealthy_rid)
+            for unhealthy_rid in self.healtcheck.get_unhealthy_rids()
+        ]
 
     def perform_surgeries(self):
-        there_is_nothing_we_can_do = []
-        surgeries = []
-        for unhealthy_rid in self.healtcheck.get_unhealthy_rids():
-            doctor = CatalogDoctor(self.catalog, unhealthy_rid)
-            if doctor.can_perform_surgery():
-                surgery = doctor.perform_surgery()
-                surgeries.append(surgery)
-            else:
-                there_is_nothing_we_can_do.append(unhealthy_rid)
+        for doctor in self.doctors:
+            doctor.perform_surgery()
 
-        return there_is_nothing_we_can_do, surgeries
+        for doctor in self.doctors:
+            doctor.perform_post_op()
+
+    def is_successful(self):
+        return all(doctor.can_perform_surgery() for doctor in self.doctors)
+
+    def write_result(self, formatter):
+        there_is_nothing_we_can_do = []
+        for doctor in self.doctors:
+            if doctor.can_perform_surgery():
+                doctor.write_result(formatter)
+                formatter.info('')
+            else:
+                there_is_nothing_we_can_do.append(doctor.unhealthy_rid)
+
+        if there_is_nothing_we_can_do:
+            formatter.info('The following unhealthy rids could not be fixed:')
+            for unhealthy_rid in there_is_nothing_we_can_do:
+                unhealthy_rid.write_result(formatter)
+                formatter.info('')
+
+            formatter.info('Not all health problems could be fixed, aborting.')

--- a/ftw/catalogdoctor/surgery.py
+++ b/ftw/catalogdoctor/surgery.py
@@ -317,42 +317,6 @@ class RemoveOrphanedRid(Surgery):
             self.surgery_log.append("Reindexed object.")
 
 
-class ReindexMissingUUID(Surgery):
-    """Reindex an uuid which is partially missing from the UID index.
-
-    Removing and reindexing the object seems to do the trick in such cases.
-    """
-    def perform(self):
-        rid = self.unhealthy_rid.rid
-
-        if len(self.unhealthy_rid.paths) != 1:
-            raise CantPerformSurgery(
-                "Expected exactly one affected path, got: {}"
-                .format(", ".join(self.unhealthy_rid.paths)))
-
-        path = list(self.unhealthy_rid.paths)[0]
-
-        portal = api.portal.get()
-        obj = portal.unrestrictedTraverse(path, None)
-        if obj is None:
-            raise CantPerformSurgery(
-                "Missing object at {}".format(path))
-
-        if self.is_potential_rid_duplicate_from_acquisition(obj, path):
-            self.unindex_rid_duplicate_from_acquisition(obj, path, rid)
-            return
-
-        # update UID index
-        index = self.catalog.indexes['UID']
-        RemoveFromUUIDIndex(index, rid).perform()
-        index.index_object(rid, obj)
-
-        # make sure catalog metadata is up to date as well
-        self.catalog.updateMetadata(obj, path, rid)
-
-        self.surgery_log.append("Reindexed UID index and updated metadata.")
-
-
 class RemoveRidOrReindexObject(Surgery):
     """Reindex an object for all indexes or remove the stray rid.
 
@@ -407,6 +371,9 @@ class RemoveRidOrReindexObject(Surgery):
             self.unindex_rid_duplicate_from_acquisition(obj, path, rid)
             return
 
+        # drop rid from indexes before reindex to make sure we have a clean
+        # new state and potential partial entries are removed before reindexing
+        self.unindex_rid_from_all_catalog_indexes(rid)
         # the object is still there and somehow vanished from the indexes.
         # we reindex to update indexes and metadata.
         obj.reindexObject()
@@ -459,7 +426,7 @@ class CatalogDoctor(object):
         (
             'in_catalog_not_in_uuid_index',
             'in_uuid_unindex_not_in_uuid_index',
-        ): ReindexMissingUUID,
+        ): RemoveRidOrReindexObject,
         (
             'in_catalog_not_in_uuid_index',
             'in_catalog_not_in_uuid_unindex',

--- a/ftw/catalogdoctor/tests/__init__.py
+++ b/ftw/catalogdoctor/tests/__init__.py
@@ -68,6 +68,15 @@ class FunctionalTestCase(TestCase):
             healthcheck_result, catalog=self.portal_catalog)
         return scheduler.perform_surgeries()
 
+    def assert_no_unhealthy_rids(self):
+        result = self.run_healthcheck()
+        formatter = MockFormatter()
+        result.write_result(formatter)
+        msg = '\n'.join(
+            ['Expected healthy catalog but found:'] + formatter.getlines()
+        )
+        self.assertTrue(result.is_healthy(), msg=msg)
+
     def choose_next_rid(self):
         """Return a currently unused rid for testing.
 

--- a/ftw/catalogdoctor/tests/__init__.py
+++ b/ftw/catalogdoctor/tests/__init__.py
@@ -199,7 +199,7 @@ class FunctionalTestCase(TestCase):
         self.maybe_process_indexing_queue()
         return ob
 
-    def recatalog_object_with_new_rid(self, obj, drop_from_indexes=True):
+    def recatalog_object_with_new_rid(self, obj, drop_from_indexes=True, rid=None):
         """Make catalog unhealthy by recataloging an object with a new rid.
 
         This will leave the old rid behind in catalog metadata and in the
@@ -211,6 +211,13 @@ class FunctionalTestCase(TestCase):
 
         path = '/'.join(obj.getPhysicalPath())
         del self.catalog.uids[path]
+        if rid:
+            # prepare insert with the specified rid, make sure catalog length
+            # is correct in that case
+            assert rid not in self.catalog.paths
+            self.catalog.uids[path] = rid
+            self.catalog.paths[rid] = path
+            self.catalog._length.change(1)
 
         self.catalog.catalogObject(obj, path)
 

--- a/ftw/catalogdoctor/tests/test_surgery.py
+++ b/ftw/catalogdoctor/tests/test_surgery.py
@@ -47,8 +47,7 @@ class TestSurgery(FunctionalTestCase):
         self.assertIs(RemoveExtraRid, doctor.get_surgery())
         self.perform_surgeries(result)
 
-        result = self.run_healthcheck()
-        self.assertTrue(result.is_healthy())
+        self.assert_no_unhealthy_rids()
 
     def test_surgery_remove_extra_rid_without_partial_uuid(self):
         self.recatalog_object_with_new_rid(self.child)
@@ -70,8 +69,7 @@ class TestSurgery(FunctionalTestCase):
         self.assertIs(RemoveExtraRid, doctor.get_surgery())
         self.perform_surgeries(result)
 
-        result = self.run_healthcheck()
-        self.assertTrue(result.is_healthy())
+        self.assert_no_unhealthy_rids()
 
     def test_surgery_remove_extra_rid_with_stale_uuid(self):
         self.recatalog_object_with_new_rid(self.child, drop_from_indexes=False)
@@ -103,8 +101,7 @@ class TestSurgery(FunctionalTestCase):
 
         self.perform_surgeries(result)
 
-        result = self.run_healthcheck()
-        self.assertTrue(result.is_healthy())
+        self.assert_no_unhealthy_rids()
 
     def test_surgery_remove_orphaned_rid_not_in_indexes(self):
         path = '/'.join(self.child.getPhysicalPath())
@@ -129,8 +126,7 @@ class TestSurgery(FunctionalTestCase):
         self.assertIs(RemoveOrphanedRid, doctor.get_surgery())
         self.perform_surgeries(result)
 
-        result = self.run_healthcheck()
-        self.assertTrue(result.is_healthy())
+        self.assert_no_unhealthy_rids()
 
     def test_surgery_remove_orphaned_rid_in_indexes(self):
         self.make_orphaned_rid(self.child)
@@ -154,8 +150,7 @@ class TestSurgery(FunctionalTestCase):
         self.assertIs(RemoveOrphanedRid, doctor.get_surgery())
         self.perform_surgeries(result)
 
-        result = self.run_healthcheck()
-        self.assertTrue(result.is_healthy())
+        self.assert_no_unhealthy_rids()
 
     def test_surgery_remove_orphaned_rid_where_object_still_present(self):
         rid = self.get_rid(self.child)
@@ -183,8 +178,7 @@ class TestSurgery(FunctionalTestCase):
         self.assertIs(RemoveOrphanedRid, doctor.get_surgery())
         self.perform_surgeries(result)
 
-        result = self.run_healthcheck()
-        self.assertTrue(result.is_healthy())
+        self.assert_no_unhealthy_rids()
 
         self.assertDictContainsSubset(
             {'Creator': 'test_user_1_',
@@ -233,8 +227,7 @@ class TestSurgery(FunctionalTestCase):
         self.assertIs(ReindexMissingUUID, doctor.get_surgery())
         self.perform_surgeries(result)
 
-        result = self.run_healthcheck()
-        self.assertTrue(result.is_healthy())
+        self.assert_no_unhealthy_rids()
 
     def test_surgery_drop_duplicate_from_acquisition_from_catalog_for_missing_uuid(self):
         grandchild = create(Builder('folder')
@@ -271,8 +264,7 @@ class TestSurgery(FunctionalTestCase):
         self.assertIs(ReindexMissingUUID, doctor.get_surgery())
         self.perform_surgeries(result)
 
-        result = self.run_healthcheck()
-        self.assertTrue(result.is_healthy())
+        self.assert_no_unhealthy_rids()
 
         self.assertNotIn(old_grandchild_path, self.catalog.uids)
         self.assertNotIn(rid, self.catalog.paths)
@@ -340,8 +332,7 @@ class TestSurgery(FunctionalTestCase):
         self.assertIs(RemoveRidOrReindexObject, doctor.get_surgery())
         self.perform_surgeries(result)
 
-        result = self.run_healthcheck()
-        self.assertTrue(result.is_healthy())
+        self.assert_no_unhealthy_rids()
 
     def test_surgery_remove_object_moved_with_parent_and_found_via_acquisition(self):
         level_1 = create(Builder('folder')
@@ -380,8 +371,7 @@ class TestSurgery(FunctionalTestCase):
         self.assertIs(RemoveRidOrReindexObject, doctor.get_surgery())
         self.perform_surgeries(result)
 
-        result = self.run_healthcheck()
-        self.assertTrue(result.is_healthy())
+        self.assert_no_unhealthy_rids()
 
     def test_surgery_add_dropped_object_to_indices(self):
         self.drop_object_from_catalog_indexes(self.parent)
@@ -403,8 +393,7 @@ class TestSurgery(FunctionalTestCase):
         self.assertIs(RemoveRidOrReindexObject, doctor.get_surgery())
         self.perform_surgeries(result)
 
-        result = self.run_healthcheck()
-        self.assertTrue(result.is_healthy())
+        self.assert_no_unhealthy_rids()
 
         self.assertDictContainsSubset(
             {'Creator': 'test_user_1_',
@@ -463,5 +452,4 @@ class TestSurgery(FunctionalTestCase):
         self.assertNotIn(rid, self.catalog.paths)
         self.assertNotIn(rid, self.catalog.data)
 
-        result = self.run_healthcheck()
-        self.assertTrue(result.is_healthy())
+        self.assert_no_unhealthy_rids()

--- a/ftw/catalogdoctor/tests/test_surgery.py
+++ b/ftw/catalogdoctor/tests/test_surgery.py
@@ -2,7 +2,6 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.catalogdoctor.exceptions import CantPerformSurgery
 from ftw.catalogdoctor.surgery import CatalogDoctor
-from ftw.catalogdoctor.surgery import ReindexMissingUUID
 from ftw.catalogdoctor.surgery import RemoveExtraRid
 from ftw.catalogdoctor.surgery import RemoveOrphanedRid
 from ftw.catalogdoctor.surgery import RemoveRidOrReindexObject
@@ -97,7 +96,7 @@ class TestSurgery(FunctionalTestCase):
         doctor = CatalogDoctor(self.catalog, unhealthy[0])
         self.assertIs(RemoveExtraRid, doctor.get_surgery())
         doctor = CatalogDoctor(self.catalog, unhealthy[1])
-        self.assertIs(ReindexMissingUUID, doctor.get_surgery())
+        self.assertIs(RemoveRidOrReindexObject, doctor.get_surgery())
 
         self.perform_surgeries(result)
 
@@ -224,7 +223,7 @@ class TestSurgery(FunctionalTestCase):
             result.get_symptoms(unhealthy_rid.rid))
 
         doctor = CatalogDoctor(self.catalog, unhealthy_rid)
-        self.assertIs(ReindexMissingUUID, doctor.get_surgery())
+        self.assertIs(RemoveRidOrReindexObject, doctor.get_surgery())
         self.perform_surgeries(result)
 
         self.assert_no_unhealthy_rids()
@@ -261,7 +260,7 @@ class TestSurgery(FunctionalTestCase):
             result.get_symptoms(unhealthy_rid.rid))
 
         doctor = CatalogDoctor(self.catalog, unhealthy_rid)
-        self.assertIs(ReindexMissingUUID, doctor.get_surgery())
+        self.assertIs(RemoveRidOrReindexObject, doctor.get_surgery())
         self.perform_surgeries(result)
 
         self.assert_no_unhealthy_rids()


### PR DESCRIPTION
With this PR we defer reindexing until removal from indexes is done. This enables fixing problems in case of symptoms are discovered in a previously undocumented/untested order.

When unhealthy rids affect the same object we need to wait with reindexing until all traces of that object are removed from the catalog by other surgeries. Otherwise it may cause the wrong rid to be picked by the reindex in the catalog causing the following surgeries to be unsuccessful.

We introduce post-op operations and a reindexing queue. Reindexing should be deferred until removal from the catalog is complete and will then be performed by post-op. We use the `SurgeryScheduler` introduced in https://github.com/4teamwork/ftw.catalogdoctor/pull/8 to perform surgery and post-op for all unhealthy rids.

As already suspected in https://github.com/4teamwork/ftw.catalogdoctor/pull/11 we also drop the specialised `ReindexMissingUUID` which is just a special case of the generic reindex implemented in `RemoveRidOrReindexObject`. We have now discovered problems in production where only reindexing the `UID` index does not suffice as the object is broken for allmost all indexes when discovering the symptoms `in_catalog_not_in_uuid_index` and `in_uuid_unindex_not_in_uuid_index`.

Jira: https://4teamwork.atlassian.net/browse/CA-365